### PR TITLE
Support setting bootstrap nodes using CLI flags

### DIFF
--- a/util/bootstraps.go
+++ b/util/bootstraps.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+type bootstrapAddrs []multiaddr.Multiaddr
+
+var (
+	// Stores the bootstrap multiaddrs
+	bootstraps bootstrapAddrs
+
+	// Used to avoid re-defining 'bootstraps' if AddbootstrapAddrs() is
+	// called multiple times. After the first call, it should simply
+	// return the slice of bootstrap addresses.
+	bootstrapsFlagLoaded = false
+)
+
+func (addrs *bootstrapAddrs) String() string {
+	return fmt.Sprintf("%v", *addrs)
+}
+
+func (addrs *bootstrapAddrs) Set(val string) error {
+	newAddr, err := multiaddr.NewMultiaddr(val)
+	if err != nil {
+		return err
+	}
+
+	for _, ma := range *addrs {
+		if ma.String() == newAddr.String() {
+			return nil // Skip append
+		}
+	}
+
+	*addrs = append(*addrs, newAddr)
+	return nil
+}
+
+// Returns address to a slice of strings that will store the bootstrap
+// multiaddresses once flag.Parse() is called (prior to that, it will
+// be an empty slice).
+func AddBootstrapFlags() (*bootstrapAddrs, error) {
+	if !bootstrapsFlagLoaded {
+		flag.Var(&bootstraps, "bootstrap",
+			"Multiaddress of a bootstrap node.\n"+
+				"This flag can be specified multiple times.")
+
+		bootstrapsFlagLoaded = true
+	}
+
+	return &bootstraps, nil
+}

--- a/util/bootstraps_test.go
+++ b/util/bootstraps_test.go
@@ -1,0 +1,95 @@
+package util_test
+
+import (
+	//"flag"
+	//"os"
+	"testing"
+
+	"github.com/Multi-Tier-Cloud/common/util"
+)
+
+/*  Keeping this here for manual testing purposes
+ *  This custom TestMain enables users to pass the -bootstrap flags when
+ *  running the test. E.g.
+ *      go test -bootstrap <multiaddr-1> -bootstrap <multiaddr-2>
+ */
+//func TestMain(test *testing.M) {
+//    _, err := util.AddBootstrapFlags()
+//    if err != nil {
+//        test.Fatalf("Unable to add bootstrap flags")
+//    }
+//
+//    flag.Parse()
+//
+//    os.Exit(test.Run())
+//}
+
+const (
+	testMultiAddr1 = "/ip4/10.11.17.15/tcp/4001/ipfs/QmeZvvPZgrpgSLFyTYwCUEbyK6Ks8Cjm2GGrP2PA78zjAk"
+	testMultiAddr2 = "/ip4/10.11.17.32/tcp/4001/ipfs/12D3KooWGegi4bWDPw9f6x2mZ6zxtsjR8w4ax1tEMDKCNqdYBt7X"
+	testBadAddr    = "/hello/World"
+)
+
+func TestAddBootstrapFlags(test *testing.T) {
+    // Test calling AddBootstrapFlags() multiple times
+	bootstraps, err := util.AddBootstrapFlags()
+	if err != nil {
+		test.Fatalf("ERROR: Unable to add bootstrap flags")
+	}
+
+	bootstraps2, err := util.AddBootstrapFlags()
+	if err != nil {
+		test.Fatalf("ERROR: Unable to add bootstrap flags")
+	}
+
+	if bootstraps != bootstraps2 {
+		test.Fatalf("ERROR: Subsequent calls to AddBootstrapFlags() returned " +
+			"different values. They should be the same.")
+	}
+
+    // Test setting a bad address
+	err = bootstraps.Set(testBadAddr)
+	if err == nil {
+		test.Fatalf("ERROR: Sucecssfully set bad address (%s) for bootstrap. "+
+			"Expected it to fail", testBadAddr)
+	}
+
+    // Test setting a proper address
+	err = bootstraps.Set(testMultiAddr1)
+    if err != nil {
+        test.Fatalf("ERROR: Setting address (%s) failed.", testMultiAddr1)
+    }
+
+    if len(*bootstraps) != 1 {
+        test.Fatalf("ERROR: Set address (%s), but it did not get added to the list of addresses.", testMultiAddr1)
+    }
+
+    // Test setting the same address again.
+	err = bootstraps.Set(testMultiAddr1)
+    if err != nil {
+        test.Fatalf("ERROR: Setting the same address (%s) failed.\n" +
+            "Expected setting duplicate addresses to succeed (idempotent).", testMultiAddr1)
+    }
+
+    if len(*bootstraps) != 1 {
+        test.Fatalf("ERROR: Set address (%s) a second time and the list of " +
+            "addresses appears to have changed.", testMultiAddr1)
+    }
+
+	err = bootstraps.Set(testMultiAddr2)
+    if err != nil {
+        test.Fatalf("ERROR: Setting address (%s) failed.", testMultiAddr2)
+    }
+
+    if len(*bootstraps) != 2 {
+        test.Fatalf("ERROR: Added new address (%s), the list of addresses " +
+            "should have increased.", testMultiAddr2)
+    }
+
+    // Test printing works
+    printTest := bootstraps.String()
+    if len(printTest) <= 2 {
+        test.Fatalf("ERROR: Expected String() to print the list of bootstrap nodes set." +
+            "Received a string length of (%d), was expected > 2.", len(printTest))
+    }
+}


### PR DESCRIPTION
  - Can specify the same flag multiple times to create a list of multiaddresses
  - Included preliminary tests
  - Preliminary work to support removal of hard-coded bootstraps (#3)