### PR TITLE
Support for Private Networks via Pre-Sharked Keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/Multi-Tier-Cloud/common
 go 1.13
 
 require (
-	github.com/libp2p/go-libp2p v0.5.2
-	github.com/libp2p/go-libp2p-core v0.3.0
-	github.com/libp2p/go-libp2p-discovery v0.2.0
+	github.com/libp2p/go-libp2p v0.9.2
+	github.com/libp2p/go-libp2p-core v0.5.6
+	github.com/libp2p/go-libp2p-discovery v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.5.0
-	github.com/multiformats/go-multiaddr v0.2.0
+	github.com/multiformats/go-multiaddr v0.2.2
 )

--- a/util/bootstraps.go
+++ b/util/bootstraps.go
@@ -30,7 +30,7 @@ var (
 	// Stores the bootstrap multiaddrs
 	bootstraps bootstrapAddrs
 
-	// Used to avoid re-defining 'bootstraps' if AddbootstrapAddrs() is
+	// Used to avoid re-defining 'bootstraps' if AddBootstrapFlags() is
 	// called multiple times. After the first call, it should simply
 	// return the slice of bootstrap addresses.
 	bootstrapsFlagLoaded = false

--- a/util/psk.go
+++ b/util/psk.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"crypto/rand"
+	"fmt"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/libp2p/go-libp2p-core/pnet"
+)
+
+// Generates a random PSK
+func CreateRandPSK() (pnet.PSK, error) {
+	randBytes := make([]byte, 32)
+	if size, err := rand.Read(randBytes); size != 32 || err != nil {
+		return nil, fmt.Errorf("Unable to generate random bytes")
+	}
+
+	digest := sha3.Sum256(randBytes)
+
+	// Convert [32]byte to []byte
+	return digest[:], nil
+}
+
+// Uses SHA256 to hash an input string into a 256-bit value.
+// This matches libp2p's current implementation for PSK, which
+// seems to be hard-coded to be 32 Bytes (256 bits) long.
+//
+// If the input string is the zero-value (i.e. ""), then this function
+// call is equivalent to calling CreateRandPSK(), which generates a
+// random pre-shared key.
+func CreatePSK(psk string) (pnet.PSK, error) {
+	if psk == "" {
+		return CreateRandPSK()
+	}
+
+	digest := sha3.Sum256([]byte(psk))
+
+	// Convert [32]byte to []byte
+	return digest[:], nil
+}

--- a/util/psk.go
+++ b/util/psk.go
@@ -2,10 +2,26 @@ package util
 
 import (
 	"crypto/rand"
+	"flag"
 	"fmt"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/libp2p/go-libp2p-core/pnet"
+)
+
+// Need to define custom type to implement flag's Value interface.
+// Don't want to expose it outside the package as it'll be redundant and
+// possibly reduce readability and comprehension of the underlying type.
+type pskValue pnet.PSK
+
+var (
+	// Stores the bootstrap multiaddrs
+	psk pskValue
+
+	// Used to avoid re-defining 'psk' if AddPSKFlag() is
+	// called multiple times. After the first call, it should simply
+	// return a pointer to the psk.
+	pskFlagLoaded = false
 )
 
 // Generates a random PSK
@@ -37,4 +53,46 @@ func CreatePSK(psk string) (pnet.PSK, error) {
 
 	// Convert [32]byte to []byte
 	return digest[:], nil
+}
+
+func (pskVal *pskValue) String() string {
+	return string(*pskVal)
+}
+
+func (pskVal *pskValue) Set(s string) error {
+	var err error
+	var pnetPsk pnet.PSK
+	if s == "" {
+		pnetPsk, err = CreateRandPSK()
+		if err != nil {
+			return fmt.Errorf("Unable to create random PSK\n%w", err)
+		}
+	} else {
+		pnetPsk, err = CreatePSK(s)
+		if err != nil {
+			return fmt.Errorf("Unable to create PSK from \"%s\"\n%w", s, err)
+		}
+	}
+
+	// Cast and return
+	*pskVal = (pskValue)(pnetPsk)
+	return nil
+}
+
+// Sets the "-psk" flag and returns a pointer to a pre-shared key
+func AddPSKFlag() (*pnet.PSK, error) {
+	if !pskFlagLoaded {
+		flag.Var(&psk, "psk",
+			"Passphrase used to create a pre-shared key (PSK) used amongst nodes "+
+				"to form a private network. The passphrase provided here will not be "+
+				"stored in memory. It is HIGHLY RECOMMENDED you use a passphrase you "+
+				"can easily memorize, or write it down somewhere safe. If you forget "+
+				"the passphrase, you will be unable to join new nodes/services to "+
+				"the same network.")
+
+		pskFlagLoaded = true
+	}
+
+	// Cast and return
+	return (*pnet.PSK)(&psk), nil
 }

--- a/util/psk.go
+++ b/util/psk.go
@@ -1,3 +1,17 @@
+/* Copyright 2020 Multi-Tier-Cloud Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package util
 
 import (
@@ -14,6 +28,9 @@ import (
 // possibly reduce readability and comprehension of the underlying type.
 type pskValue pnet.PSK
 
+// libp2p's PSK definition is a slice of 32 bytes
+const PSK_NUM_BYTES = 32
+
 var (
 	// Stores the bootstrap multiaddrs
 	psk pskValue
@@ -26,8 +43,8 @@ var (
 
 // Generates a random PSK
 func CreateRandPSK() (pnet.PSK, error) {
-	randBytes := make([]byte, 32)
-	if size, err := rand.Read(randBytes); size != 32 || err != nil {
+	randBytes := make([]byte, PSK_NUM_BYTES)
+	if size, err := rand.Read(randBytes); size != PSK_NUM_BYTES || err != nil {
 		return nil, fmt.Errorf("Unable to generate random bytes")
 	}
 
@@ -95,4 +112,11 @@ func AddPSKFlag() (*pnet.PSK, error) {
 
 	// Cast and return
 	return (*pnet.PSK)(&psk), nil
+}
+
+// For enabling tests, ideally should not be used.
+// This is needed to return a pointer to type pskValue, a hidden type.
+// This enables tests for the Set() and String() functions above.
+func GetPSKPointer() *pskValue {
+	return &psk
 }

--- a/util/psk_test.go
+++ b/util/psk_test.go
@@ -1,0 +1,109 @@
+/* Copyright 2020 Multi-Tier-Cloud Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package util_test
+
+import (
+	//"flag"
+	//"os"
+	"reflect"
+	"testing"
+
+	"github.com/Multi-Tier-Cloud/common/util"
+)
+
+var (
+	testPassphrase = "toInfinityAndBeyond!"
+)
+
+/*  Keeping this here for manual testing purposes
+ *  This custom TestMain enables users to pass the -bootstrap flags when
+ *  running the test. E.g.
+ *      go test -psk <pre-shared-key-passphrase>
+ */
+//func TestMain(test *testing.M) {
+//    _, err := util.AddPSKFlag()
+//    if err != nil {
+//        test.Fatalf("Unable to add PSK flag")
+//    }
+//
+//    flag.Parse()
+//
+//    os.Exit(test.Run())
+//}
+
+func TestAddPSKFlag(test *testing.T) {
+	// Test calling AddBootstrapFlags() multiple times
+	psk, err := util.AddPSKFlag()
+	if err != nil {
+		test.Fatalf("ERROR: Unable to add PSK flag")
+	}
+
+	psk2, err := util.AddPSKFlag()
+	if err != nil {
+		test.Fatalf("ERROR: Unable to add PSK flag")
+	}
+
+	if psk != psk2 {
+		test.Fatalf("ERROR: Subsequent calls to AddPSKFlag() returned " +
+			"different values. They should be the same.")
+	}
+}
+
+func TestPSKSetString(test *testing.T) {
+	psk := util.GetPSKPointer()
+
+	// Test setting with an empty string (should generate a random PSK)
+	err := psk.Set("")
+	if err != nil {
+		test.Fatalf("ERROR: Setting PSK flag with \"\" failed.\n")
+	}
+
+	tmp := *psk
+
+	err = psk.Set("") // Generates random PSK again
+	if err != nil {
+		test.Fatalf("ERROR: Setting PSK flag with \"\" a second time failed.\n")
+	}
+
+	if reflect.DeepEqual(tmp, *psk) {
+		test.Errorf("ERROR: Expected new random PSK to be generated when Set()" +
+			"is called with an empty string \"\", but they were identical.\n")
+	}
+
+	// Test setting with same passphrase twice
+	err = psk.Set(testPassphrase)
+	if err != nil {
+		test.Fatalf("ERROR: Setting PSK flag with \"%s\" failed.\n", testPassphrase)
+	}
+
+	tmp = *psk
+
+	err = psk.Set(testPassphrase)
+	if err != nil {
+		test.Fatalf("ERROR: Setting PSK flag with \"%s\" a second time failed.\n", testPassphrase)
+	}
+
+	if !reflect.DeepEqual(tmp, *psk) {
+		test.Errorf("ERROR: Expected the same PSK to be generated when Set()" +
+			"is called twice with the same psk passphrase, but they differed.\n")
+	}
+
+	// Test printing works
+	printTest := psk.String()
+	if len(printTest) != util.PSK_NUM_BYTES {
+		test.Fatalf("ERROR: Expected PSK String() to return a 32-character value, "+
+			"but it returned a %d characters instead.\n", len(printTest))
+	}
+}


### PR DESCRIPTION
- Includes support for a PSK flag to specify a passphrase that'll be used to generate the PSK.
  - This was briefly tested (offline) with bootstrap node.
- Tests for new files are included.
- Updated pinned libp2p library versions in go.mod

