### PR TITLE
Support passing bootstraps and PSK via environment variables

### DIFF
--- a/p2pnode/p2pnode.go
+++ b/p2pnode/p2pnode.go
@@ -30,9 +30,11 @@ import (
     "github.com/libp2p/go-libp2p-core/pnet"
     "github.com/libp2p/go-libp2p-core/protocol"
     "github.com/libp2p/go-libp2p-discovery"
-
     "github.com/libp2p/go-libp2p-kad-dht"
+
     "github.com/multiformats/go-multiaddr"
+
+    "github.com/Multi-Tier-Cloud/common/util"
 )
 
 
@@ -61,21 +63,6 @@ type Node struct {
     Host               host.Host
     DHT                *dht.IpfsDHT
     RoutingDiscovery   *discovery.RoutingDiscovery
-}
-
-// Helper function to cast a slice of strings into a slice of Multiaddrs
-func StringsToMultiaddrs(stringMultiaddrs []string) ([]multiaddr.Multiaddr, error) {
-    multiaddrs := make([]multiaddr.Multiaddr, 0)
-
-    for _, s := range stringMultiaddrs {
-        ma, err := multiaddr.NewMultiaddr(s)
-        if err != nil {
-            return multiaddrs, err
-        }
-        multiaddrs = append(multiaddrs, ma)
-    }
-
-    return multiaddrs, nil
 }
 
 const (
@@ -108,7 +95,7 @@ func NewNode(ctx context.Context, config Config) (Node, error) {
 
     // Set listen addresses if they exist
     if len(config.ListenAddrs) != 0 {
-        listenAddrs, err := StringsToMultiaddrs(config.ListenAddrs)
+        listenAddrs, err := util.StringsToMultiaddrs(config.ListenAddrs)
         if err != nil {
             return node, err
         }

--- a/util/bootstraps.go
+++ b/util/bootstraps.go
@@ -17,6 +17,8 @@ package util
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/multiformats/go-multiaddr"
 )
@@ -25,6 +27,8 @@ import (
 // Don't want to expose it outside the package as it'll be redundant and
 // possibly reduce readability and comprehension of the underlying type.
 type bootstrapAddrs []multiaddr.Multiaddr
+
+const ENV_KEY_BOOTSTRAPS = "P2P_BOOTSTRAPS"
 
 var (
 	// Stores the bootstrap multiaddrs
@@ -77,4 +81,23 @@ func AddBootstrapFlags() (*[]multiaddr.Multiaddr, error) {
 
 	// Cast and return
 	return (*[]multiaddr.Multiaddr)(&bootstraps), nil
+}
+
+// If the environment variable does not exist, or if there are errors during
+// parsing, return the 0-value of the return type.
+func GetEnvBootstraps() ([]multiaddr.Multiaddr, error) {
+	envStr := os.Getenv(ENV_KEY_BOOTSTRAPS)
+	if envStr == "" {
+		return []multiaddr.Multiaddr{}, nil
+	}
+
+	bootstraps, err := StringsToMultiaddrs(strings.Fields(envStr))
+	if err != nil {
+		err = fmt.Errorf("ERROR: Unable to parse environment variable %s.\n%w",
+			ENV_KEY_BOOTSTRAPS, err)
+
+		return []multiaddr.Multiaddr{}, err
+	}
+
+	return bootstraps, nil
 }

--- a/util/bootstraps_test.go
+++ b/util/bootstraps_test.go
@@ -16,7 +16,8 @@ package util_test
 
 import (
 	//"flag"
-	//"os"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/Multi-Tier-Cloud/common/util"
@@ -109,5 +110,45 @@ func TestBootstrapSetString(test *testing.T) {
 	if len(printTest) <= 2 {
 		test.Fatalf("ERROR: Expected String() to print the list of bootstrap nodes set."+
 			"Received a string length of (%d), was expected > 2.", len(printTest))
+	}
+}
+
+func TestGetEnvBootstraps(test *testing.T) {
+	// Set the environment variable, then call GetEnvBootstraps()
+	fakeEnvVal := "\t  /ip4/10.11.69.5/tcp/36277/p2p/QmPqv37ukZLuVKfz5vBaH5KyMR9FCo8FuaRpXg7aKwcsgN\t\n\r   " +
+		"/ip4/10.11.69.20/tcp/40863/p2p/Qmaq76Lt4oEiYEbkxwCb6CgKbbp9qw5eWTexsrm84D2hJW\t\t\r\n "
+	fakeEnvLength := len(strings.Fields(fakeEnvVal))
+
+	err := os.Setenv(util.ENV_KEY_BOOTSTRAPS, fakeEnvVal)
+	if err != nil {
+		test.Fatalf("ERROR: Unable to set environment variable %s\n", util.ENV_KEY_BOOTSTRAPS)
+	}
+
+	bootstraps, err := util.GetEnvBootstraps()
+	if err != nil {
+		test.Fatalf("ERROR: Case with environment variable set, "+
+			"GetEnvBootstraps() failed with error:\n%v\n", err)
+	}
+
+	if len(bootstraps) != fakeEnvLength {
+		test.Errorf("ERROR: GetEnvBootstraps() returned %d addresses. Expected "+
+			"it to return %d instead\n", len(bootstraps), fakeEnvLength)
+	}
+
+	// Unset environment variable and re-test
+	err = os.Unsetenv(util.ENV_KEY_BOOTSTRAPS)
+	if err != nil {
+		test.Fatalf("ERROR: Unable to unset environment variable %s\n", util.ENV_KEY_BOOTSTRAPS)
+	}
+
+	bootstraps, err = util.GetEnvBootstraps()
+	if err != nil {
+		test.Fatalf("ERROR: Case with no environment variable set, "+
+			"GetEnvBootstraps() failed with error:\n%v\n", err)
+	}
+
+	if len(bootstraps) != 0 {
+		test.Errorf("ERROR: GetEnvBootstraps() returned %d addresses. Expected "+
+			"none since no environment variable was set\n", len(bootstraps))
 	}
 }

--- a/util/psk.go
+++ b/util/psk.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"golang.org/x/crypto/sha3"
+	"os"
 
 	"github.com/libp2p/go-libp2p-core/pnet"
 )
@@ -28,8 +29,12 @@ import (
 // possibly reduce readability and comprehension of the underlying type.
 type pskValue pnet.PSK
 
-// libp2p's PSK definition is a slice of 32 bytes
-const PSK_NUM_BYTES = 32
+const (
+	// libp2p's PSK definition is a slice of 32 bytes
+	PSK_NUM_BYTES = 32
+
+	ENV_KEY_PSK = "P2P_PSK"
+)
 
 var (
 	// Stores the bootstrap multiaddrs
@@ -119,4 +124,23 @@ func AddPSKFlag() (*pnet.PSK, error) {
 // This enables tests for the Set() and String() functions above.
 func GetPSKPointer() *pskValue {
 	return &psk
+}
+
+// If the environment variable does not exist, or if there are errors during
+// parsing, return the 0-value of the return type.
+func GetEnvPSK() (pnet.PSK, error) {
+	envStr := os.Getenv(ENV_KEY_PSK)
+	if envStr == "" {
+		return pnet.PSK{}, nil
+	}
+
+	pnetPsk, err := CreatePSK(envStr)
+	if err != nil {
+		err = fmt.Errorf("ERROR: Unable to parse environment variable %s.\n%w",
+			ENV_KEY_PSK, err)
+
+		return pnet.PSK{}, err
+	}
+
+	return pnetPsk, nil
 }

--- a/util/psk_test.go
+++ b/util/psk_test.go
@@ -16,7 +16,7 @@ package util_test
 
 import (
 	//"flag"
-	//"os"
+	"os"
 	"reflect"
 	"testing"
 
@@ -28,7 +28,7 @@ var (
 )
 
 /*  Keeping this here for manual testing purposes
- *  This custom TestMain enables users to pass the -bootstrap flags when
+ *  This custom TestMain enables users to pass the -psk flag when
  *  running the test. E.g.
  *      go test -psk <pre-shared-key-passphrase>
  */
@@ -44,7 +44,6 @@ var (
 //}
 
 func TestAddPSKFlag(test *testing.T) {
-	// Test calling AddBootstrapFlags() multiple times
 	psk, err := util.AddPSKFlag()
 	if err != nil {
 		test.Fatalf("ERROR: Unable to add PSK flag")
@@ -105,5 +104,43 @@ func TestPSKSetString(test *testing.T) {
 	if len(printTest) != util.PSK_NUM_BYTES {
 		test.Fatalf("ERROR: Expected PSK String() to return a 32-character value, "+
 			"but it returned a %d characters instead.\n", len(printTest))
+	}
+}
+
+func TestGetEnvPSK(test *testing.T) {
+	// Set the environment variable, then call GetEnvPSK()
+	fakeEnvVal := "\t  helloWorldPassphrase     \r\n\t "
+
+	err := os.Setenv(util.ENV_KEY_PSK, fakeEnvVal)
+	if err != nil {
+		test.Fatalf("ERROR: Unable to set environment variable %s\n", util.ENV_KEY_PSK)
+	}
+
+	psk, err := util.GetEnvPSK()
+	if err != nil {
+		test.Fatalf("ERROR: Case with environment variable set, "+
+			"GetEnvPSK() failed with error:\n%v\n", err)
+	}
+
+	if len(psk) != util.PSK_NUM_BYTES {
+		test.Errorf("ERROR: GetEnvPSK() returned a key with length %d. "+
+			"Expected the length to be %d\n", len(psk), util.PSK_NUM_BYTES)
+	}
+
+	// Unset environment variable and re-test
+	err = os.Unsetenv(util.ENV_KEY_PSK)
+	if err != nil {
+		test.Fatalf("ERROR: Unable to unset environment variable %s\n", util.ENV_KEY_PSK)
+	}
+
+	psk, err = util.GetEnvPSK()
+	if err != nil {
+		test.Fatalf("ERROR: Case with no environment variable set, "+
+			"GetEnvPSK() failed with error:\n%v\n", err)
+	}
+
+	if len(psk) != 0 {
+		test.Errorf("ERROR: GetEnvPSK() returned a key with length %d. Expected "+
+			"length 0 since no environment variable was set\n", len(psk))
 	}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"os"
 	"strings"
+
+	"github.com/multiformats/go-multiaddr"
 )
 
 // Get preferred outbound ip on machine
@@ -76,3 +78,17 @@ func FileExists(filePath string) bool {
 	return true
 }
 
+// Helper function to cast a slice of strings into a slice of Multiaddrs
+func StringsToMultiaddrs(stringMultiaddrs []string) ([]multiaddr.Multiaddr, error) {
+	multiaddrs := make([]multiaddr.Multiaddr, 0)
+
+	for _, s := range stringMultiaddrs {
+		ma, err := multiaddr.NewMultiaddr(s)
+		if err != nil {
+			return multiaddrs, err
+		}
+		multiaddrs = append(multiaddrs, ma)
+	}
+
+	return multiaddrs, nil
+}


### PR DESCRIPTION
Environment variable names are: **P2P_BOOTSTRAPS** and **P2P_PSK**

**P2P_BOOTSTRAPS** supports a whitespace-separated list of multiaddresses, so users can pass in multiple bootstraps simultaneously.